### PR TITLE
Rename workflow to fix CI badge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 on: [push, pull_request]
 
-name: Continuous integration
+name: CI
 
 jobs:
   check:


### PR DESCRIPTION
The current badge image URI returns `404 Not Found` as it points to a workflow named "CI". This fixes it by renaming the workflow to "CI" instead of "Continuous integration"
