### PR TITLE
Exclude tests and examples from the crates.io package.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/sunfishcode/is-terminal"
 keywords = ["terminal", "tty", "isatty"]
 categories = ["command-line-interface"]
 license = "MIT"
-exclude = ["/.github"]
 edition = "2018"
+include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md"]
 
 [dependencies]
 io-lifetimes = "0.7.1"


### PR DESCRIPTION
This shrinks the generated package size from 6581 bytes to 6501 bytes.