### PR TITLE
Add a rust-version declaration to Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["command-line-interface"]
 license = "MIT"
 edition = "2018"
 include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md"]
+rust-version = "1.48"
 
 [dependencies]
 io-lifetimes = "1.0.0"


### PR DESCRIPTION
This isn't recognized in Rust 1.48, but it's harmlessly ignored when used as a dependency.