### PR TITLE
Fix the GetFileInformationByHandleEx function usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,6 @@ atty = "0.2.14"
 
 [target.'cfg(any(unix, target_os = "wasi"))'.dev-dependencies]
 libc = "0.2.110"
+
+[target.'cfg(windows)'.dev-dependencies]
+tempfile  = "3"


### PR DESCRIPTION
There are two issues in the current implementation of the `msys_tty_on` function. Firstly, the size returned by the `GetFileInformationByHandleEx` function is the size in bytes not in characters. Secondly, the path can exceed the `MAX_PATH` constant.

I stumbled upon this issue when some of our tests [begin to fail](https://github.com/mintlayer/mintlayer-core/pull/592) on Windows after the update to the `env_logger` 0.10 version which switches to the `is-terminal` crate.