### PR TITLE
Add "Win32_Storage_FileSystem" to the windows-sys dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ hermit-abi = "0.2.0"
 version = "0.42.0"
 features = [
     "Win32_Foundation",
+    "Win32_Storage_FileSystem",
     "Win32_System_Console",
 ]
 


### PR DESCRIPTION
Fix as suggested by @michalburger1. Fixes #13.