### PR TITLE
Add 'is_terminal' function for importless checking.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,10 @@ pub trait IsTerminal {
 
 /// Returns `true` if `this` is a terminal.
 ///
+/// This is equivalent to calling `this.is_terminal()` and exists only as a
+/// convenience to calling the trait method [`IsTerminal::is_terminal()`]
+/// without importing the trait.
+///
 /// # Example
 ///
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ use std::os::windows::io::AsRawHandle;
 #[cfg(windows)]
 use windows_sys::Win32::Foundation::HANDLE;
 
+/// Extension trait to check whether something is a terminal.
 pub trait IsTerminal {
     /// Returns true if this is a terminal.
     ///
@@ -51,6 +52,19 @@ pub trait IsTerminal {
     /// }
     /// ```
     fn is_terminal(&self) -> bool;
+}
+
+/// Returns `true` if `this` is a terminal.
+///
+/// # Example
+///
+/// ```
+/// if is_terminal::is_terminal(&std::io::stdout()) {
+///     println!("stdout is a terminal")
+/// }
+/// ```
+pub fn is_terminal<T: IsTerminal>(this: &T) -> bool {
+    this.is_terminal()
 }
 
 #[cfg(not(target_os = "unknown"))]


### PR DESCRIPTION
As in the title. Just a convenience. I just don't want to import a trait when a simple function will do.