### PR TITLE
Upgrade http links to https in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Dan Gohman <dev@sunfishcode.online>"
 ]
 description = "Test whether a given stream is a terminal"
-documentation = "http://docs.rs/is-terminal"
+documentation = "https://docs.rs/is-terminal"
 repository = "https://github.com/sunfishcode/is-terminal"
 keywords = ["terminal", "tty", "isatty"]
 categories = ["command-line-interface"]


### PR DESCRIPTION
This is an automatically-generated PR to update plain HTTP links in Cargo.toml

If there are any issues with this, you can reach out to @/Benjins on Github who is the original author of this automated PR

In file `Cargo.toml`:
 - `http://docs.rs/is-terminal` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS

