### PR TITLE
Use 'libc' directly instead of through rustix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ edition = "2018"
 include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md"]
 rust-version = "1.63"
 
-[target.'cfg(not(any(windows, target_os = "hermit", target_os = "unknown")))'.dependencies]
-rustix = { version = "0.38.0", features = ["termios"] }
+[target.'cfg(any(unix, target_os = "wasi"))'.dependencies]
+libc = "0.2"
 
 [target.'cfg(target_os = "hermit")'.dependencies]
 hermit-abi = "0.3.0"
@@ -33,6 +33,7 @@ features = [
 atty = "0.2.14"
 
 [target.'cfg(any(unix, target_os = "wasi"))'.dev-dependencies]
+rustix = { version = "0.38.0", features = ["termios"] }
 libc = "0.2.110"
 
 [target.'cfg(not(any(windows, target_os = "hermit", target_os = "unknown")))'.dev-dependencies]


### PR DESCRIPTION
As the title suggests, this PR goes from using `rustix` to check if a stream is a terminal on Unix to using `libc` directly. The benefit is a decrease in compile-times by ~50% in debug mode and ~35% in release mode, on my machine, as well a decrease in transitive dependencies from 5 to 2. The detriment is an added use of `unsafe`, albeit a very well understood one.

```sh
# with rustix, before
$ cargo build
   Compiling libc v0.2.144
   Compiling io-lifetimes v1.0.11
   Compiling rustix v0.37.19
   Compiling bitflags v1.3.2
   Compiling errno v0.3.1
   Compiling is-terminal v0.4.7
    Finished dev [unoptimized + debuginfo] target(s) in 1.11s
```

```sh
# without rustix, after
$ cargo build
   Compiling libc v0.2.144
   Compiling io-lifetimes v1.0.11
   Compiling is-terminal v0.4.7
    Finished dev [unoptimized + debuginfo] target(s) in 0.63s
```