### PR TITLE
Update to rustix 0.38 and bump the MSRV to 1.63.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,10 @@ categories = ["command-line-interface"]
 license = "MIT"
 edition = "2018"
 include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md"]
-rust-version = "1.48"
-
-[dependencies]
-io-lifetimes = "1.0.0"
+rust-version = "1.63"
 
 [target.'cfg(not(any(windows, target_os = "hermit", target_os = "unknown")))'.dependencies]
-rustix = { version = "0.37.0", features = ["termios"] }
+rustix = { version = "0.38.0", features = ["termios"] }
 
 [target.'cfg(target_os = "hermit")'.dependencies]
 hermit-abi = "0.3.0"
@@ -37,6 +34,9 @@ atty = "0.2.14"
 
 [target.'cfg(any(unix, target_os = "wasi"))'.dev-dependencies]
 libc = "0.2.110"
+
+[target.'cfg(not(any(windows, target_os = "hermit", target_os = "unknown")))'.dev-dependencies]
+rustix = { version = "0.38.0", features = ["stdio"] }
 
 [target.'cfg(windows)'.dev-dependencies]
 tempfile  = "3"

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ stderr? false
 # Minimum Supported Rust Version (MSRV)
 
 This crate currently works on the version of [Rust on Debian stable], which is
-currently Rust 1.48. This policy may change in the future, in minor version
+currently Rust 1.63. This policy may change in the future, in minor version
 releases, so users using a fixed version of Rust should pin to a specific
 version of this crate.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,14 +27,12 @@
 
 #![cfg_attr(unix, no_std)]
 
-#[cfg(not(target_os = "unknown"))]
-use io_lifetimes::AsFilelike;
-#[cfg(windows)]
-use io_lifetimes::BorrowedHandle;
+#[cfg(not(any(windows, target_os = "unknown")))]
+use rustix::fd::AsFd;
 #[cfg(target_os = "hermit")]
 use std::os::hermit::io::AsRawFd;
 #[cfg(windows)]
-use std::os::windows::io::AsRawHandle;
+use std::os::windows::io::{AsHandle, AsRawHandle, BorrowedHandle};
 #[cfg(windows)]
 use windows_sys::Win32::Foundation::HANDLE;
 
@@ -67,12 +65,12 @@ pub trait IsTerminal {
 ///     println!("stdout is a terminal")
 /// }
 /// ```
-pub fn is_terminal<T: IsTerminal>(this: &T) -> bool {
+pub fn is_terminal<T: IsTerminal>(this: T) -> bool {
     this.is_terminal()
 }
 
-#[cfg(not(target_os = "unknown"))]
-impl<Stream: AsFilelike> IsTerminal for Stream {
+#[cfg(not(any(windows, target_os = "unknown")))]
+impl<Stream: AsFd> IsTerminal for Stream {
     #[inline]
     fn is_terminal(&self) -> bool {
         #[cfg(any(unix, target_os = "wasi"))]
@@ -82,13 +80,16 @@ impl<Stream: AsFilelike> IsTerminal for Stream {
 
         #[cfg(target_os = "hermit")]
         {
-            hermit_abi::isatty(self.as_filelike().as_raw_fd())
+            hermit_abi::isatty(self.as_fd().as_raw_fd())
         }
+    }
+}
 
-        #[cfg(windows)]
-        {
-            handle_is_console(self.as_filelike())
-        }
+#[cfg(windows)]
+impl<Stream: AsHandle> IsTerminal for Stream {
+    #[inline]
+    fn is_terminal(&self) -> bool {
+        handle_is_console(self.as_handle())
     }
 }
 
@@ -313,7 +314,7 @@ mod tests {
     fn stdin() {
         assert_eq!(
             atty::is(atty::Stream::Stdin),
-            rustix::io::stdin().is_terminal()
+            rustix::stdio::stdin().is_terminal()
         )
     }
 
@@ -322,7 +323,7 @@ mod tests {
     fn stdout() {
         assert_eq!(
             atty::is(atty::Stream::Stdout),
-            rustix::io::stdout().is_terminal()
+            rustix::stdio::stdout().is_terminal()
         )
     }
 
@@ -331,7 +332,7 @@ mod tests {
     fn stderr() {
         assert_eq!(
             atty::is(atty::Stream::Stderr),
-            rustix::io::stderr().is_terminal()
+            rustix::stdio::stderr().is_terminal()
         )
     }
 
@@ -341,7 +342,7 @@ mod tests {
         unsafe {
             assert_eq!(
                 libc::isatty(libc::STDIN_FILENO) != 0,
-                rustix::io::stdin().is_terminal()
+                rustix::stdio::stdin().is_terminal()
             )
         }
     }
@@ -352,7 +353,7 @@ mod tests {
         unsafe {
             assert_eq!(
                 libc::isatty(libc::STDOUT_FILENO) != 0,
-                rustix::io::stdout().is_terminal()
+                rustix::stdio::stdout().is_terminal()
             )
         }
     }
@@ -363,7 +364,7 @@ mod tests {
         unsafe {
             assert_eq!(
                 libc::isatty(libc::STDERR_FILENO) != 0,
-                rustix::io::stderr().is_terminal()
+                rustix::stdio::stderr().is_terminal()
             )
         }
     }


### PR DESCRIPTION
On Linux, this speeds up the in-tree from-scratch build times of is-terminal by about 3x.