### PR TITLE
Default to using libc on Unix and WASI.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,13 @@ repository = "https://github.com/sunfishcode/is-terminal"
 keywords = ["terminal", "tty", "isatty"]
 categories = ["command-line-interface"]
 license = "MIT"
-edition = "2018"
+edition = "2021"
 include = ["src", "build.rs", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md"]
 rust-version = "1.63"
 
-[target.'cfg(not(any(windows, target_os = "hermit", target_os = "unknown")))'.dependencies]
-rustix = { version = "0.38.0", features = ["termios"] }
+[target.'cfg(any(unix, target_os = "wasi"))'.dependencies]
+rustix = { version = "0.38.0", features = ["termios"], default-features = false, optional = true }
+libc = { version = "0.2", optional = true }
 
 [target.'cfg(target_os = "hermit")'.dependencies]
 hermit-abi = "0.3.0"
@@ -33,10 +34,18 @@ features = [
 atty = "0.2.14"
 
 [target.'cfg(any(unix, target_os = "wasi"))'.dev-dependencies]
+rustix = { version = "0.38.0", features = ["termios", "stdio"] }
 libc = "0.2.110"
-
-[target.'cfg(not(any(windows, target_os = "hermit", target_os = "unknown")))'.dev-dependencies]
-rustix = { version = "0.38.0", features = ["stdio"] }
 
 [target.'cfg(windows)'.dev-dependencies]
 tempfile  = "3"
+
+[features]
+default = ["std", "libc"]
+std = []
+
+# rustix using std.
+rustix-std = ["std", "rustix/std"]
+
+# rustix using no_std.
+rustix-no_std = ["rustix"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,11 @@
 
 #[cfg(all(any(unix, target_os = "wasi"), feature = "rustix"))]
 use rustix::fd::AsFd;
-#[cfg(all(any(unix, target_os = "wasi"), feature = "libc"))]
+#[cfg(all(
+    any(unix, target_os = "wasi"),
+    feature = "libc",
+    not(feature = "rustix")
+))]
 use std::os::fd::{AsFd, AsRawFd};
 #[cfg(target_os = "hermit")]
 use std::os::hermit::io::AsFd;
@@ -80,7 +84,11 @@ impl<Stream: AsFd> IsTerminal for Stream {
             rustix::termios::isatty(self)
         }
 
-        #[cfg(all(any(unix, target_os = "wasi"), feature = "libc"))]
+        #[cfg(all(
+            any(unix, target_os = "wasi"),
+            feature = "libc",
+            not(feature = "rustix")
+        ))]
         unsafe {
             libc::isatty(self.as_fd().as_raw_fd()) != 0
         }


### PR DESCRIPTION
Switch is-terminal on Unix and WASI to use `libc` instead of `rustix` by default. This matches the `IsTerminal` implementation in std, and avoids pulling in all of rustix as a dependency just for one function.

This retains rustix as an option, which may be enabled by using `default-features = false` and enabling either the `rustix-std` or `rustix-no_std` features.
