### PR TITLE
Make the implementation match std.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,8 @@ impl<Stream: AsFd> IsTerminal for Stream {
     fn is_terminal(&self) -> bool {
         #[cfg(any(unix, target_os = "wasi"))]
         {
-            unsafe { libc::isatty(self.as_fd().as_raw_fd()) == 1 }
+            let fd = self.as_fd();
+            unsafe { libc::isatty(fd.as_raw_fd()) != 0 }
         }
 
         #[cfg(target_os = "hermit")]
@@ -104,8 +105,8 @@ impl<Stream: AsHandle> IsTerminal for Stream {
 }
 
 // The Windows implementation here is copied from `handle_is_console` in
-// std/src/sys/windows/io.rs in Rust at revision
-// d7b0bcb20f2f7d5f3ea3489d56ece630147e98f5.
+// library/std/src/sys/pal/windows/io.rs in Rust at revision
+// 99128b7e45f8b95d962da2e6ea584767f0c85455.
 
 #[cfg(windows)]
 fn handle_is_console(handle: BorrowedHandle<'_>) -> bool {
@@ -147,8 +148,6 @@ fn handle_is_console(handle: BorrowedHandle<'_>) -> bool {
 }
 
 /// Returns true if there is an MSYS tty on the given handle.
-///
-/// This incoproates d7b0bcb20f2f7d5f3ea3489d56ece630147e98f5
 #[cfg(windows)]
 unsafe fn msys_tty_on(handle: HANDLE) -> bool {
     use std::ffi::c_void;


### PR DESCRIPTION
Use `!= 0` instead of `== 1` for testing `isatty`'s return value, so that this code follows std as closely as possible.

And update the comments in the Windows implementation to reflect that this code matches what's in current std as well.