### PR TITLE
Fix compilation on Rust 1.63.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, nightly]
+        build: [msrv, stable, nightly]
         include:
+          - build: msrv
+            os: ubuntu-latest
+            rust: 1.63
           - build: stable
             os: ubuntu-latest
             rust: stable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,10 +36,12 @@
     no_std
 )]
 
-#[cfg(any(unix, target_os = "wasi"))]
-use std::os::fd::{AsFd, AsRawFd};
 #[cfg(target_os = "hermit")]
 use std::os::hermit::io::AsFd;
+#[cfg(unix)]
+use std::os::unix::io::{AsFd, AsRawFd};
+#[cfg(target_os = "wasi")]
+use std::os::wasi::io::{AsFd, AsRawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsHandle, AsRawHandle, BorrowedHandle};
 #[cfg(windows)]


### PR DESCRIPTION
Avoid using std::os::fd, which isn't available until Rust 1.66. And add Rust 1.63 testing in CI.